### PR TITLE
Update Gradle and Loom and also remove deprecations in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.6-SNAPSHOT'
+	id 'fabric-loom' version '0.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -11,7 +11,6 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-    jcenter()
     maven {
         url "https://www.cursemaven.com"
     }
@@ -38,7 +37,7 @@ dependencies {
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
-	compile "com.logisticscraft:occlusionculling:0.0.3-SNAPSHOT"
+	implementation "com.logisticscraft:occlusionculling:0.0.3-SNAPSHOT"
     extraLibs "com.logisticscraft:occlusionculling:0.0.3-SNAPSHOT"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Follow-up from #10 
fixes #22 

this is because Gradle 7.0 is a stable release and Loom 0.7 will soon be the recommended version