### PR TITLE
Add Draconic Evolution's TileEntities to default config for 1.16

### DIFF
--- a/EntityCulling-Shared/src/main/java/dev/tr7zw/entityculling/Config.java
+++ b/EntityCulling-Shared/src/main/java/dev/tr7zw/entityculling/Config.java
@@ -8,7 +8,18 @@ public class Config {
 
     public int configVersion = 4;
     public boolean renderNametagsThroughWalls = true;
-    public Set<String> blockEntityWhitelist = new HashSet<>(Arrays.asList("minecraft:beacon", "create:rope_pulley", "create:hose_pulley", "betterend:eternal_pedestal", "draconicevolution:storage_core"));
+    public Set<String> blockEntityWhitelist = new HashSet<>(Arrays.asList(
+            "minecraft:beacon",
+            "create:rope_pulley",
+            "create:hose_pulley",
+            "betterend:eternal_pedestal",
+            "draconicevolution:storage_core",
+            "draconicevolution:core_stabilizer",
+            "draconicevolution:reactor_core",
+            "draconicevolution:reactor_stabilizer",
+            "draconicevolution:reactor_injector",
+            "draconicevolution:grinder"
+    ));
     public int tracingDistance = 128;
     public boolean debugMode = false;
     public int sleepDelay = 10;

--- a/EntityCulling-Shared/src/main/java/dev/tr7zw/entityculling/Config.java
+++ b/EntityCulling-Shared/src/main/java/dev/tr7zw/entityculling/Config.java
@@ -8,7 +8,7 @@ public class Config {
 
     public int configVersion = 4;
     public boolean renderNametagsThroughWalls = true;
-    public Set<String> blockEntityWhitelist = new HashSet<>(Arrays.asList("minecraft:beacon", "create:rope_pulley", "create:hose_pulley", "betterend:eternal_pedestal"));
+    public Set<String> blockEntityWhitelist = new HashSet<>(Arrays.asList("minecraft:beacon", "create:rope_pulley", "create:hose_pulley", "betterend:eternal_pedestal", "draconicevolution:storage_core"));
     public int tracingDistance = 128;
     public boolean debugMode = false;
     public int sleepDelay = 10;


### PR DESCRIPTION
Might want to repeat this change on 1.17 as well, but I picked the 1.16-backport branch because DE is only on 1.16 for now.