### PR TITLE
Add mcmod.info to 1.8.9

### DIFF
--- a/EntityCulling-Forge/src/main/resources/META-INF/mcmod.info
+++ b/EntityCulling-Forge/src/main/resources/META-INF/mcmod.info
@@ -1,0 +1,14 @@
+[
+  {
+    "modid": "entityculling",
+    "name": "EntityCulling",
+    "url": "https://github.com/tr7zw/EntityCulling",
+    "version": "1.6.2",
+    "description": "Using async raytracing to hide Tile-/Entities that are hidden behind solid blocks.",
+    "logoFile": "assets/entityculling/icon.png",
+    "mcversion": "1.8.9",
+    "authorList": [
+      "tr7zw"
+    ]
+  }
+]


### PR DESCRIPTION
1.8 contains the modern `mods.toml` which is not used by FML in this version. A legacy `mcmod.info` has been created using the same information that is found in the `mods.toml`.