### PR TITLE
Whitelist Alex's Caves Gum Worm entity in Config

### DIFF
--- a/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
+++ b/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
@@ -21,7 +21,8 @@ public class Config {
     public Set<String> tickCullingWhitelist = new HashSet<>(
             Arrays.asList("minecraft:firework_rocket", "minecraft:boat", "create:carriage_contraption",
                     "create:contraption", "create:gantry_contraption", "create:stationary_contraption",
-                    "mts:builder_existing", "mts:builder_rendering", "mts:builder_seat", "drg_flares:drg_flares"));
+                    "mts:builder_existing", "mts:builder_rendering", "mts:builder_seat",
+                    "drg_flares:drg_flares", "alexscaves:gum_worm", "alexscaves:gum_worm_segment"));
     public boolean disableF3 = false;
     public boolean skipEntityCulling = false;
     public boolean skipBlockEntityCulling = false;


### PR DESCRIPTION
Entity Culling breaks the render of these mobs, who dig in and out of the terrain, meaning that raytracing their position isn't always accurately culling them.