### PR TITLE
Added translation key for keybind category (fix issue #172)

### DIFF
--- a/src/main/java/dev/tr7zw/entityculling/EntityCullingModBase.java
+++ b/src/main/java/dev/tr7zw/entityculling/EntityCullingModBase.java
@@ -27,7 +27,7 @@ public abstract class EntityCullingModBase extends EntityCullingVersionlessBase 
     public Set<EntityType<?>> entityWhistelist = new HashSet<>();
     public Set<EntityType<?>> tickCullWhistelist = new HashSet<>();
     public CullTask cullTask;
-    protected KeyMapping keybind = new KeyMapping("key.entityculling.toggle", -1, "EntityCulling");
+    protected KeyMapping keybind = new KeyMapping("key.entityculling.toggle", -1, "text.entityculling.title");
     private Set<Function<BlockEntity, Boolean>> dynamicBlockEntityWhitelist = new HashSet<>();
     private Set<Function<Entity, Boolean>> dynamicEntityWhitelist = new HashSet<>();
 


### PR DESCRIPTION
Use a translation key for the title of the keybind category. This allows resource packs to change the title without changing the mod (#172).