### PR TITLE
Whitelist avm_staff:campfire_flame entity

### DIFF
--- a/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
+++ b/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
@@ -21,7 +21,8 @@ public class Config {
     public Set<String> tickCullingWhitelist = new HashSet<>(Arrays.asList("minecraft:firework_rocket", "minecraft:boat",
             "create:carriage_contraption", "create:contraption", "create:gantry_contraption",
             "create:stationary_contraption", "mts:builder_existing", "mts:builder_rendering", "mts:builder_seat",
-            "drg_flares:drg_flares", "drg_flares:drg_flare", "alexscaves:gum_worm", "alexscaves:gum_worm_segment"));
+            "drg_flares:drg_flares", "drg_flares:drg_flare", "alexscaves:gum_worm", "alexscaves:gum_worm_segment",
+            "avm_staff:campfire_flame"));
     public boolean disableF3 = false;
     public boolean skipEntityCulling = false;
     public boolean skipBlockEntityCulling = false;


### PR DESCRIPTION
`avm_staff:campfire_flame` is a [technical entity](https://github.com/opekope2/StaffMod/blob/e9e9ca8a691f9718dad75c45d50852269245b963/StaffMod/src/main/kotlin/opekope2/avm_staff/content/EntityTypes.kt#L59-L74), which has a dimension of 0x0x0, and gets culled. However, it's not rendered as an entity, but rather, it spawns particles in its way (similar to `minecraft:area_effect_cloud`).