### PR TITLE
Optimize 1.7.10 TE whitelist

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,77 +1,109 @@
+# ExampleMod tag to use as Blowdryer (Spotless, etc.) settings version, leave empty to disable.
+# LOCAL to test local config updates.
+gtnh.settings.blowdryerTag = 0.2.2
+
+# Human-readable mod name, available for mcmod.info population.
 modName = EntityCulling
 
-# This is a case-sensitive string to identify your mod. Convention is to use lower case.
+# Case-sensitive identifier string, available for mcmod.info population and used for automatic mixin JSON generation.
+# Conventionally lowercase.
 modId = entityculling
 
+# Root package of the mod, used to find various classes in other properties,
+# mcmod.info substitution, enabling assertions in run tasks, etc.
 modGroup = dev.tr7zw.entityculling
 
-# WHY is there no version field?
-# The build script relies on git to provide a version via tags. It is super easy and will enable you to always know the
-# code base or your binary. Check out this tutorial: https://blog.mattclemente.com/2017/10/13/versioning-with-git-tags/
+# Whether to use modGroup as the maven publishing group.
+# Due to a history of using JitPack, the default is com.github.GTNewHorizons for all mods.
+useModGroupForPublishing = false
 
-# Will update your build.gradle automatically whenever an update is available
+# Updates your build.gradle and settings.gradle automatically whenever an update is available.
 autoUpdateBuildScript = false
 
+# Version of Minecraft to target
 minecraftVersion = 1.7.10
+
+# Version of Minecraft Forge to target
 forgeVersion = 10.13.4.1614
 
-# Specify a MCP channel and mappings version for dependency deobfuscation and the deobfParams task.
+# Specify an MCP channel for dependency deobfuscation and the deobfParams task.
 channel = stable
+
+# Specify an MCP mappings version for dependency deobfuscation and the deobfParams task.
 mappingsVersion = 12
 
-# Define other MCP mappings for dependency deobfuscation
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+# Defines other MCP mappings for dependency deobfuscation.
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
-# Select a username for testing your mod with breakpoints. You may leave this empty for a random username each time you
-# restart Minecraft in development. Choose this dependent on your mod:
-# Do you need consistent player progressing (for example Thaumcraft)? -> Select a name
-# Do you need to test how your custom blocks interacts with a player that is not the owner? -> leave name empty
+# Select a default username for testing your mod. You can always override this per-run by running
+# `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
 developmentEnvironmentUserName = Developer
 
-# Enables using modern java syntax (up to version 17) via Jabel, while still targeting JVM 8.
+# Enables using modern Java syntax (up to version 17) via Jabel, while still targeting JVM 8.
 # See https://github.com/bsideup/jabel for details on how this works.
 enableModernJavaSyntax = true
 
-# Enables injecting missing generics into the decompiled source code for a better coding experience
-# Turns most publicly visible List, Map, etc. into proper List<Type>, Map<K, V> types
+# Enables injecting missing generics into the decompiled source code for a better coding experience.
+# Turns most publicly visible List, Map, etc. into proper List<E>, Map<K, V> types.
 enableGenericInjection = true
 
-# Generate a class with String fields for the mod id, name, version and group name named with the fields below
+# Generate a class with a String field for the mod version named as defined below.
+# If generateGradleTokenClass is empty or not missing, no such class will be generated.
+# If gradleTokenVersion is empty or missing, the field will not be present in the class.
 generateGradleTokenClass = com.myname.mymodid.Tags
-gradleTokenModId = MODID
-gradleTokenModName = MODNAME
+
+# Name of the token containing the project's current version to generate/replace.
 gradleTokenVersion = VERSION
+
+# [DEPRECATED] Mod ID replacement token.
+gradleTokenModId = MODID
+
+# [DEPRECATED] Mod name replacement token.
+gradleTokenModName = MODNAME
+
+# [DEPRECATED] Mod Group replacement token.
 gradleTokenGroupName = GROUPNAME
+
 # [DEPRECATED]
-# Multiple source files can be defined here by providing a comma-seperated list: Class1.java,Class2.java,Class3.java
+# Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";
 # The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
-# version in @Mod([...], version = VERSION, [...])
-# Leave these properties empty to skip individual token replacements
+# version in @Mod([...], version = VERSION, [...]).
+# Leave these properties empty to skip individual token replacements.
 replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.
-# Example value: apiPackage = api + modGroup = com.myname.mymodid -> com.myname.mymodid.api
+# Example value: (apiPackage = api) + (modGroup = com.myname.mymodid) -> com.myname.mymodid.api
 apiPackage =
 
 # Specify the configuration file for Forge's access transformers here. It must be placed into /src/main/resources/META-INF/
-# There can be multiple files in a comma-separated list.
-# Example value: mymodid_at.cfg,nei_at.cfg
+# There can be multiple files in a space-separated list.
+# Example value: mymodid_at.cfg nei_at.cfg
 accessTransformersFile =
 
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = true
-# Adds some debug arguments like verbose output and export
+
+# Set to a non-empty string to configure mixins in a separate source set under src/VALUE, instead of src/main.
+# This can speed up compile times thanks to not running the mixin annotation processor on all input sources.
+# Mixin classes will have access to "main" classes, but not the other way around.
+separateMixinSourceSet =
+
+# Adds some debug arguments like verbose output and class export.
 usesMixinDebug = true
+
 # Specify the location of your implementation of IMixinConfigPlugin. Leave it empty otherwise.
 mixinPlugin =
+
 # Specify the package that contains all of your Mixins. You may only place Mixins in this package or the build will fail!
 mixinsPackage = mixin
+
 # Specify the core mod entry class if you use a core mod. This class must implement IFMLLoadingPlugin!
 # This parameter is for legacy compatibility only
-# Example value: coreModClass = asm.FMLPlugin + modGroup = com.myname.mymodid -> com.myname.mymodid.asm.FMLPlugin
+# Example value: (coreModClass = asm.FMLPlugin) + (modGroup = com.myname.mymodid) -> com.myname.mymodid.asm.FMLPlugin
 coreModClass =
+
 # If your project is only a consolidation of mixins or a core mod and does NOT contain a 'normal' mod ( = some class
 # that is annotated with @Mod) you want this to be true. When in doubt: leave it on false!
 containsMixinsAndOrCoreModOnly = false
@@ -79,28 +111,38 @@ containsMixinsAndOrCoreModOnly = false
 # Enables Mixins even if this mod doesn't use them, useful if one of the dependencies uses mixins.
 forceEnableMixins = false
 
-# If enabled, you may use 'shadowCompile' for dependencies. They will be integrated in your jar. It is your
-# responsibility check the licence and request permission for distribution, if required.
+# If enabled, you may use 'shadowCompile' for dependencies. They will be integrated into your jar. It is your
+# responsibility to check the license and request permission for distribution if required.
 usesShadowedDependencies = true
-# If disabled, won't remove unused classes from shaded dependencies. Some libraries use reflection to access
+
+# If disabled, won't remove unused classes from shadowed dependencies. Some libraries use reflection to access
 # their own classes, making the minimization unreliable.
 minimizeShadowedDependencies = true
+
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories
+# Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
+# A list of repositories to exclude from the includeWellKnownRepositories setting. Should be a space separated
+# list of strings, with the acceptable keys being(case does not matter):
+# cursemaven
+# modrinth
+excludeWellKnownRepositories =
+
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
-# Authenticate with the MAVEN_USERNAME and MAVEN_PASSWORD environment variables.
+# Authenticate with the MAVEN_USER and MAVEN_PASSWORD environment variables.
 # If you need a more complex setup disable maven publishing here and add a publishing repository to addon.gradle.
-# usesMavenPublishing = true
-# mavenPublishUrl = http://jenkins.usrv.eu:8081/nexus/content/repositories/releases
+usesMavenPublishing = true
 
-# Publishing to modrinth requires you to set the MODRINTH_TOKEN environment variable to your current modrinth API token.
+# Maven repository to publish the mod to.
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
+# Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
+#
 # The project's ID on Modrinth. Can be either the slug or the ID.
-# Leave this empty if you don't want to publish on Modrinth.
+# Leave this empty if you don't want to publish to Modrinth.
 modrinthProjectId =
 
 # The project's relations on Modrinth. You can use this to refer to other projects on Modrinth.
@@ -112,9 +154,8 @@ modrinthProjectId =
 # Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
 modrinthRelations =
 
-
 # Publishing to CurseForge requires you to set the CURSEFORGE_TOKEN environment variable to one of your CurseForge API tokens.
-
+#
 # The project's numeric ID on CurseForge. You can find this in the About Project box.
 # Leave this empty if you don't want to publish on CurseForge.
 curseForgeProjectId =
@@ -124,29 +165,39 @@ curseForgeProjectId =
 # Where type can be one of [requiredDependency, embeddedLibrary, optionalDependency, tool, incompatible],
 #       and the name is the CurseForge project slug of the other mod.
 # Example: requiredDependency:railcraft;embeddedLibrary:cofhlib;incompatible:buildcraft
-# Note: GTNH Mixins is automatically set as a required dependency if usesMixins = true
+# Note: UniMixins is automatically set as a required dependency if usesMixins = true.
 curseForgeRelations =
 
-
-# Optional parameter to customize the produced artifacts. Use this to preserver artifact naming when migrating older
+# Optional parameter to customize the produced artifacts. Use this to preserve artifact naming when migrating older
 # projects. New projects should not use this parameter.
 # customArchiveBaseName =
 
-# Optional parameter to prevent the source code from being published
-# noPublishedSources =
+# Optional parameter to have the build automatically fail if an illegal version is used.
+# This can be useful if you e.g. only want to allow versions in the form of '1.1.xxx'.
+# The check is ONLY performed if the version is a git tag.
+# Note: the specified string must be escaped, so e.g. 1\\.1\\.\\d+ instead of 1\.1\.\d+
+# versionPattern =
 
-# Uncomment this to disable spotless checks
+# Uncomment to prevent the source code from being published.
+# noPublishedSources = true
+
+# Uncomment this to disable Spotless checks.
 # This should only be uncommented to keep it easier to sync with upstream/other forks.
 # That is, if there is no other active fork/upstream, NEVER change this.
 disableSpotless = true
 
-# Uncomment this to disable checkstyle checks (currently wildcard import check).
+# Uncomment this to disable Checkstyle checks (currently wildcard import check).
 # disableCheckstyle = true
 
-# Override the IDEA build type. Valid value is "" (leave blank, do not override), "idea" (force use native IDEA build), "gradle"
+# Override the IDEA build type. Valid values are: "" (leave blank, do not override), "idea" (force use native IDEA build), "gradle"
 # (force use delegated build).
 # This is meant to be set in $HOME/.gradle/gradle.properties.
-# e.g. add "systemProp.org.gradle.project.ideaOverrideBuildType=idea" will override the build type to be always native build.
+# e.g. add "systemProp.org.gradle.project.ideaOverrideBuildType=idea" will override the build type to be native build.
 # WARNING: If you do use this option, it will overwrite whatever you have in your existing projects. This might not be what you want!
 # Usually there is no need to uncomment this here as other developers do not necessarily use the same build type as you.
 # ideaOverrideBuildType = idea
+
+# Whether IDEA should run spotless checks when pressing the Build button.
+# This is meant to be set in $HOME/.gradle/gradle.properties.
+# ideaCheckSpotlessOnBuild = true
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,11 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.15'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
 }
 
-//blowdryerSetup {
-//    repoSubfolder 'gtnhShared'
-//    github('GTNewHorizons/ExampleMod1.7.10', 'tag', '0.2.2')
-    //devLocal '.' // Use this when testing config updates locally
-//}
+//

--- a/src/main/java/dev/tr7zw/entityculling/Config.java
+++ b/src/main/java/dev/tr7zw/entityculling/Config.java
@@ -8,7 +8,7 @@ public class Config {
 
     public int configVersion = 4;
     public boolean renderNametagsThroughWalls = true;
-    public Set<String> blockEntityWhitelist = new HashSet<>(Arrays.asList("tile.beacon"));
+    public Set<String> blockEntityWhitelist = new HashSet<>(Arrays.asList("beacon"));
     public int tracingDistance = 128;
     public boolean debugMode = false;
     public int sleepDelay = 10;

--- a/src/main/java/dev/tr7zw/entityculling/EntityCullingMod.java
+++ b/src/main/java/dev/tr7zw/entityculling/EntityCullingMod.java
@@ -40,6 +40,7 @@ public class EntityCullingMod extends EntityCullingModBase {
         ClientRegistry.registerKeyBinding(keybind);
         MinecraftForge.EVENT_BUS.register(this);
         FMLCommonHandler.instance().bus().register(this);
+        cullTask.populateWhitelist(config.blockEntityWhitelist);
     }
 
     @SubscribeEvent

--- a/src/main/java/dev/tr7zw/entityculling/EntityCullingModBase.java
+++ b/src/main/java/dev/tr7zw/entityculling/EntityCullingModBase.java
@@ -60,7 +60,7 @@ public abstract class EntityCullingModBase {
             }
         }
         culling = new OcclusionCullingInstance(config.tracingDistance, new Provider());
-        cullTask = new CullTask(culling, config.blockEntityWhitelist);
+        cullTask = new CullTask(culling);
 
 		cullThread = new Thread(cullTask, "CullThread");
 		cullThread.setUncaughtExceptionHandler((thread, ex) -> {


### PR DESCRIPTION
The call to `Block.getUnlocalizedName()` was generating a new String for every TE every time the CullTask ran, generating significant amounts of garbage at high framerates, changed from a Set<String> to Set<Block> for more efficient comparison.