### PR TITLE
[1.8] Reduce allocations

### DIFF
--- a/src/main/java/dev/tr7zw/entityculling/Provider.java
+++ b/src/main/java/dev/tr7zw/entityculling/Provider.java
@@ -9,8 +9,9 @@ import net.minecraft.util.BlockPos;
 public class Provider implements DataProvider {
 
     private final Minecraft client = Minecraft.getMinecraft();
+    private final BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
     private WorldClient world = null;
-    
+
     @Override
     public boolean prepareChunk(int chunkX, int chunkZ) {
         world = client.theWorld;
@@ -19,8 +20,7 @@ public class Provider implements DataProvider {
 
     @Override
     public boolean isOpaqueFullCube(int x, int y, int z) {
-        BlockPos pos = new BlockPos(x, y, z);
-        return world.getBlockState(pos).getBlock().isOpaqueCube();
+        return world.getBlockState(pos.set(x, y, z)).getBlock().isOpaqueCube();
     }
 
     @Override


### PR DESCRIPTION
Should be faster (I hope).
Before it was one of the biggest `BlockPos` allocators, now it's completely gone.

Probably applies to all other versions, I don't know how `BlockPos` works there though.
(it should matter less on modern Java which has an incremental garbage collector)