### PR TITLE
Added Immersive Vehicles Entities to the whitelist by default

### DIFF
--- a/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
+++ b/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
@@ -12,7 +12,8 @@ public class Config {
             Arrays.asList("minecraft:beacon", "create:rope_pulley", "create:hose_pulley", "betterend:eternal_pedestal",
                     "botania:magic_missile", "botania:flame_ring", "botania:falling_star"));
     public Set<String> entityWhitelist = new HashSet<>(
-            Arrays.asList("botania:mana_burst", "drg_flares:drg_flares", "quark:soul_bead"));
+            Arrays.asList("botania:mana_burst", "drg_flares:drg_flares", "quark:soul_bead",
+                          "mts:builder_existing", "mts:builder_rendering", "mts:builder_seat"));
     public int tracingDistance = 128;
     public boolean debugMode = false;
     public int sleepDelay = 10;


### PR DESCRIPTION
Added , "mts:builder_existing", "mts:builder_rendering" & "mts:builder_seat" to the default whitelist. 
This way, the mod Immersive Vehicles won't have its vehicles culled on accident anymore.

Additionally, bumped the config version up by a number so any preexisting configs can be updated as well via the configUpgrader