### PR TITLE
bug: Update default config to not break Create Big Cannons entities

### DIFF
--- a/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
+++ b/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
@@ -27,7 +27,7 @@ public class Config {
             "minecraft:oak_boat", "minecraft:oak_chest_boat", "minecraft:pale_oak_boat",
             "minecraft:pale_oak_chest_boat", "minecraft:spruce_boat", "minecraft:spruce_chest_boat",
             "minecraft:bamboo_raft", "minecraft:bamboo_chest_raft", "create:carriage_contraption", "create:contraption",
-            "create:gantry_contraption", "create:stationary_contraption", "mts:builder_existing",
+            "create:gantry_contraption", "create:stationary_contraption", "createbigcannons:pitch_contraption", "createbigcannons:cannon_carriage", "mts:builder_existing",
             "mts:builder_rendering", "mts:builder_seat", "drg_flares:drg_flares", "drg_flares:drg_flare",
             "alexscaves:gum_worm", "alexscaves:gum_worm_segment", "avm_staff:campfire_flame", "minecraft:block_display",
             "minecraft:item_display", "minecraft:text_display", "voidscape:corrupted_pawn"));


### PR DESCRIPTION
This PR fixes two entities for my mod, Create Big Cannons. I have gotten user reports of cannon contraption entities (`createbigcannons:pitch_contraption`) breaking in certain locations (mainly Sable sublevels). This also fixes culling of cannon carriages (`createbigcannons:cannon_carriages`) which can carry cannon contraptions as passengers.

Below are images of the two entities.

`createbigcannons:pitch_contraption`
<img width="1635" height="763" alt="image" src="https://github.com/user-attachments/assets/556db35a-74f7-42af-872e-e89ce30eb7ea" />

`createbigcannons:cannon_carriage`
<img width="664" height="495" alt="image" src="https://github.com/user-attachments/assets/f442282c-f1fb-4dc2-94a6-c6b67ae665fd" />

Combined
<img width="1071" height="721" alt="image" src="https://github.com/user-attachments/assets/5a4822bb-52be-44f8-a954-5fc493f5e5da" />

