### PR TITLE
Cinematic Cataclysm compatibility & whitelists alphabetical order

### DIFF
--- a/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
+++ b/EntityCulling-Versionless/src/main/java/dev/tr7zw/entityculling/versionless/Config.java
@@ -9,29 +9,75 @@ public class Config {
     public int configVersion = 7;
     public boolean renderNametagsThroughWalls = true;
     public Set<String> blockEntityWhitelist = new HashSet<>(
-            Arrays.asList("minecraft:beacon", "create:rope_pulley", "create:hose_pulley", "betterend:eternal_pedestal",
-                    "botania:magic_missile", "botania:flame_ring", "botania:falling_star"));
+            Arrays.asList(
+              "betterend:eternal_pedestal",
+              "botania:falling_star",
+              "botania:flame_ring",
+              "botania:magic_missile",
+              "create:hose_pulley",
+              "create:rope_pulley",
+              "minecraft:beacon"
+	));
     public Set<String> entityWhitelist = new HashSet<>(
-            Arrays.asList("botania:mana_burst", "drg_flares:drg_flares", "quark:soul_bead"));
+            Arrays.asList(
+              "botania:mana_burst",
+			  "drg_flares:drg_flares",
+			  "quark:soul_bead"
+	));
     public int tracingDistance = 128;
     public boolean debugMode = false;
     public int sleepDelay = 10;
     public int hitboxLimit = 50;
     public int captureRate = 5;
     public boolean tickCulling = true;
-    public Set<String> tickCullingWhitelist = new HashSet<>(Arrays.asList("minecraft:firework_rocket", "minecraft:boat",
-            "minecraft:acacia_boat", "minecraft:acacia_chest_boat", "minecraft:birch_boat",
-            "minecraft:birch_chest_boat", "minecraft:cherry_boat", "minecraft:cherry_chest_boat",
-            "minecraft:dark_oak_boat", "minecraft:dark_oak_chest_boat", "minecraft:jungle_boat",
-            "minecraft:jungle_chest_boat", "minecraft:mangrove_boat", "minecraft:mangrove_chest_boat",
-            "minecraft:oak_boat", "minecraft:oak_chest_boat", "minecraft:pale_oak_boat",
-            "minecraft:pale_oak_chest_boat", "minecraft:spruce_boat", "minecraft:spruce_chest_boat",
-            "minecraft:bamboo_raft", "minecraft:bamboo_chest_raft", "create:carriage_contraption", "create:contraption",
-            "create:gantry_contraption", "create:stationary_contraption", "createbigcannons:pitch_contraption",
-            "createbigcannons:cannon_carriage", "mts:builder_existing", "mts:builder_rendering", "mts:builder_seat",
-            "drg_flares:drg_flares", "drg_flares:drg_flare", "alexscaves:gum_worm", "alexscaves:gum_worm_segment",
-            "avm_staff:campfire_flame", "minecraft:block_display", "minecraft:item_display", "minecraft:text_display",
-            "voidscape:corrupted_pawn"));
+    public Set<String> tickCullingWhitelist = new HashSet<>(
+            Arrays.asList(
+              "alexscaves:gum_worm",
+	          "alexscaves:gum_worm_segment",
+	          "avm_staff:campfire_flame",
+			  "cinematiccataclysm:ancient_remnant_cutscene",
+    		  "cinematiccataclysm:ignis_cutscene",
+   		      "cinematiccataclysm:leviathan_cutscene",
+   		      "cinematiccataclysm:maledictus_cutscene",
+   		      "cinematiccataclysm:scylla_cutscene",
+	          "create:carriage_contraption",
+	          "create:contraption",
+	          "create:gantry_contraption",
+	          "create:stationary_contraption",
+	          "createbigcannons:cannon_carriage",
+	          "createbigcannons:pitch_contraption",
+	          "drg_flares:drg_flare",
+	          "drg_flares:drg_flares",
+	          "minecraft:acacia_boat",
+	          "minecraft:acacia_chest_boat",
+	          "minecraft:bamboo_chest_raft",
+	          "minecraft:bamboo_raft",
+	          "minecraft:birch_boat",
+	          "minecraft:birch_chest_boat",
+	          "minecraft:block_display",
+	          "minecraft:boat",
+	          "minecraft:cherry_boat",
+	          "minecraft:cherry_chest_boat",
+	          "minecraft:dark_oak_boat",
+	          "minecraft:dark_oak_chest_boat",
+	          "minecraft:firework_rocket",
+	          "minecraft:item_display",
+	          "minecraft:jungle_boat",
+	          "minecraft:jungle_chest_boat",
+	          "minecraft:mangrove_boat",
+	          "minecraft:mangrove_chest_boat",
+	          "minecraft:oak_boat",
+	          "minecraft:oak_chest_boat",
+	          "minecraft:pale_oak_boat",
+	          "minecraft:pale_oak_chest_boat",
+	          "minecraft:spruce_boat",
+	          "minecraft:spruce_chest_boat",
+	          "minecraft:text_display",
+	          "mts:builder_existing",
+	          "mts:builder_rendering",
+	          "mts:builder_seat",
+	          "voidscape:corrupted_pawn"
+	));
     public boolean disableF3 = false;
     public boolean skipEntityCulling = false;
     public boolean skipBlockEntityCulling = false;


### PR DESCRIPTION
The [Cinematic Cataclysm](https://www.curseforge.com/minecraft/mc-mods/cinematic-cataclysm) mod page specifies a requirement to make changes to the culling whitelist when using the Entity Culling mod to avoid issues. I made these changes by default.

<img width="836" height="272" alt="image" src="https://github.com/user-attachments/assets/9c3705fb-07d0-477e-9e2b-dc655fc08856" />

I also sorted all the whitelists in alphabetical order.